### PR TITLE
CI: Drop unused Travis configuration and add Circle CI SVG badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 1.9.3
-  - 2.1.0
-before_script:
-  - psql -c 'create database pipeline_test;' -U postgres
-script: "script/ci"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/barsoom/pipeline.svg?style=svg)](https://circleci.com/gh/barsoom/pipeline)
+[![CircleCI](https://circleci.com/gh/barsoom/pipeline.svg?style=svg&circle-token=fe9fb4fcd60997d3fa4a42fd3eaa1793ee11362d)](https://circleci.com/gh/barsoom/pipeline)
 [![Code Climate](https://codeclimate.com/github/joakimk/pipeline.png)](https://codeclimate.com/github/joakimk/pipeline)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/barsoom/pipeline.svg?style=svg&circle-token=fe9fb4fcd60997d3fa4a42fd3eaa1793ee11362d)](https://circleci.com/gh/barsoom/pipeline)
+[![CircleCI](https://circleci.com/gh/barsoom/pipeline.svg?style=shield&circle-token=fe9fb4fcd60997d3fa4a42fd3eaa1793ee11362d)](https://circleci.com/gh/barsoom/pipeline)
 [![Code Climate](https://codeclimate.com/github/joakimk/pipeline.png)](https://codeclimate.com/github/joakimk/pipeline)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CircleCI](https://circleci.com/gh/barsoom/pipeline.svg?style=svg)](https://circleci.com/gh/barsoom/pipeline)
 [![Code Climate](https://codeclimate.com/github/joakimk/pipeline.png)](https://codeclimate.com/github/joakimk/pipeline)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://secure.travis-ci.org/joakimk/pipeline.png)](http://travis-ci.org/joakimk/pipeline)
 [![Code Climate](https://codeclimate.com/github/joakimk/pipeline.png)](https://codeclimate.com/github/joakimk/pipeline)
 
 ## About


### PR DESCRIPTION
This PR finishes the move to CircleCI by fully dropping the Travis config.

- Replace Travis CI badge
